### PR TITLE
Add compare_and_swap, compare_exchange, compare_exchange_weak

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,14 +148,16 @@ impl<P, T> Atom<P>
 where
     P: IntoRawPtr + FromRawPtr + Deref<Target = T>,
 {
-    /// Stores a value into the pointer if the current value is the same as the
-    /// current value.
+    /// Stores `new` in the Atom if `current` has the same raw pointer
+    /// representation as the currently stored value.
     ///
-    /// The return value is always the previous value. If it is equal to
-    /// current, then the value was updated.
+    /// On success, the Atom's previous value is returned. On failure, `new` is
+    /// returned together with a raw pointer to the Atom's current unchanged
+    /// value, which is **not safe to dereference**, especially if the Atom is
+    /// accessed from multiple threads.
     ///
-    /// compare_and_swap also takes an Ordering argument which describes the
-    /// memory ordering of this operation.
+    /// `compare_and_swap` also takes an `Ordering` argument which describes
+    /// the memory ordering of this operation.
     pub fn compare_and_swap(
         &self,
         current: Option<&P>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,11 +148,14 @@ impl<P, T> Atom<P>
 where
     P: IntoRawPtr + FromRawPtr + Deref<Target = T>,
 {
-    /// Stores a value into the pointer if the current value is the same as the current value.
+    /// Stores a value into the pointer if the current value is the same as the
+    /// current value.
     ///
-    /// The return value is always the previous value. If it is equal to current, then the value was updated.
+    /// The return value is always the previous value. If it is equal to
+    /// current, then the value was updated.
     ///
-    /// compare_and_swap also takes an Ordering argument which describes the memory ordering of this operation.
+    /// compare_and_swap also takes an Ordering argument which describes the
+    /// memory ordering of this operation.
     pub fn compare_and_swap(
         &self,
         current: Option<&P>,
@@ -169,11 +172,19 @@ where
         }
     }
 
-    /// Stores a value into the pointer if the current value is the same as the `current` value.
+    /// Stores a value into the pointer if the current value is the same as the
+    /// `current` value.
     ///
-    /// The return value is a result indicating whether the new value was written and containing the previous value. On success this value is guaranteed to be equal to `current`.
+    /// The return value is a result indicating whether the new value was
+    /// written and containing the previous value. On success this value is
+    /// guaranteed to be equal to `current`.
     ///
-    /// `compare_exchange` takes two `Ordering` arguments to describe the memory ordering of this operation. The first describes the required ordering if the operation succeeds while the second describes the required ordering when the operation fails. The failure ordering can't be `Release` or `AcqRel` and must be equivalent or weaker than the success ordering.
+    /// `compare_exchange` takes two `Ordering` arguments to describe the
+    /// memory ordering of this operation. The first describes the required
+    /// ordering if the operation succeeds while the second describes the
+    /// required ordering when the operation fails. The failure ordering can't
+    /// be `Release` or `AcqRel` and must be equivalent or weaker than the
+    /// success ordering.
     pub fn compare_exchange(
         &self,
         current: Option<&P>,
@@ -188,11 +199,20 @@ where
             .map_err(|pprev| (unsafe { Self::inner_from_raw(pnew) }, pprev as *mut P))
     }
 
-    /// Stores a value into the pointer if the current value is the same as the `current` value.
+    /// Stores a value into the pointer if the current value is the same as the
+    /// `current` value.
     ///
-    /// Unlike `compare_exchange`, this function is allowed to spuriously fail even when the comparison succeeds, which can result in more efficient code on some platforms. The return value is a result indicating whether the new value was written and containing the previous value.
+    /// Unlike `compare_exchange`, this function is allowed to spuriously fail
+    /// even when the comparison succeeds, which can result in more efficient
+    /// code on some platforms. The return value is a result indicating whether
+    /// the new value was written and containing the previous value.
     ///
-    /// `compare_exchange_weak` takes two `Ordering` arguments to describe the memory ordering of this operation. The first describes the required ordering if the operation succeeds while the second describes the required ordering when the operation fails. The failure ordering can't be `Release` or `AcqRel` and must be equivalent or weaker than the success ordering.
+    /// `compare_exchange_weak` takes two `Ordering` arguments to describe the
+    /// memory ordering of this operation. The first describes the required
+    /// ordering if the operation succeeds while the second describes the
+    /// required ordering when the operation fails. The failure ordering can't
+    /// be `Release` or `AcqRel` and must be equivalent or weaker than the
+    /// success ordering.
     pub fn compare_exchange_weak(
         &self,
         current: Option<&P>,

--- a/tests/atom.rs
+++ b/tests/atom.rs
@@ -47,28 +47,76 @@ fn set_if_none() {
 }
 
 #[test]
-fn compare_and_swap() {
-    cas_test_helper(|a, cas_val, next_val| a.compare_and_swap(cas_val, next_val, Ordering::SeqCst));
+fn compare_and_swap_basics() {
+    cas_test_basics_helper(|a, cas_val, next_val| {
+        a.compare_and_swap(cas_val, next_val, Ordering::SeqCst)
+    });
 }
 
 #[test]
-fn compare_exchange() {
-    cas_test_helper(|a, cas_val, next_val| {
+fn compare_exchange_basics() {
+    cas_test_basics_helper(|a, cas_val, next_val| {
         a.compare_exchange(cas_val, next_val, Ordering::SeqCst, Ordering::SeqCst)
     });
 }
 
 #[test]
-fn compare_exchange_weak() {
-    cas_test_helper(|a, cas_val, next_val| {
+fn compare_exchange_weak_basics() {
+    cas_test_basics_helper(|a, cas_val, next_val| {
         a.compare_exchange_weak(cas_val, next_val, Ordering::SeqCst, Ordering::SeqCst)
     });
 }
 
-fn cas_test_helper(
-    cas: fn(&Atom<Arc<String>>, Option<&Arc<String>>, Option<Arc<String>>)
-        -> Result<Option<Arc<String>>, (Option<Arc<String>>, *mut Arc<String>)>,
-) {
+#[test]
+fn compare_and_swap_threads() {
+    cas_test_threads_helper(|a, cas_val, next_val| {
+        a.compare_and_swap(cas_val, next_val, Ordering::SeqCst)
+    });
+}
+
+#[test]
+fn compare_exchange_threads() {
+    cas_test_threads_helper(|a, cas_val, next_val| {
+        a.compare_exchange(cas_val, next_val, Ordering::SeqCst, Ordering::SeqCst)
+    });
+}
+
+#[test]
+fn compare_exchange_weak_threads() {
+    cas_test_threads_helper(|a, cas_val, next_val| {
+        a.compare_exchange_weak(cas_val, next_val, Ordering::SeqCst, Ordering::SeqCst)
+    });
+}
+
+type TestCASFn = fn(&Atom<Arc<String>>, Option<&Arc<String>>, Option<Arc<String>>)
+    -> Result<Option<Arc<String>>, (Option<Arc<String>>, *mut Arc<String>)>;
+
+fn cas_test_basics_helper(cas: TestCASFn) {
+    let cur_val = Arc::new("123".to_owned());
+    let mut next_val = Arc::new("456".to_owned());
+    let other_val = Arc::new("1927447".to_owned());
+
+    let a = Atom::new(cur_val.clone());
+
+    let pcur = IntoRawPtr::into_raw(cur_val.clone());
+    let pnext = IntoRawPtr::into_raw(next_val.clone());
+
+    for attempt in vec![None, Some(&other_val), Some(&Arc::new("wow".to_owned()))] {
+        let res = cas(&a, attempt, Some(next_val.clone())).unwrap_err();
+        next_val = res.0.unwrap();
+        assert_eq!(res.1, pcur as *mut _);
+    }
+
+    let res = cas(&a, Some(&cur_val), Some(next_val.clone()));
+    assert_eq!(res, Ok(Some(cur_val)));
+
+    for attempt in vec![None, Some(&other_val), Some(&Arc::new("wow".to_owned()))] {
+        let res = cas(&a, attempt, None).unwrap_err();
+        assert_eq!(res, (None, pnext as *mut _));
+    }
+}
+
+fn cas_test_threads_helper(cas: TestCASFn) {
     let cur_val = Arc::new("current".to_owned());
     let next_val = Arc::new("next".to_owned());
     let other_val = Arc::new("other".to_owned());


### PR DESCRIPTION
Add compare_and_swap, compare_exchange, compare_exchange_weak:
```rust
    // https://doc.rust-lang.org/std/sync/atomic/struct.AtomicPtr.html#method.compare_and_swap
    pub fn compare_and_swap(
        &self,
        current: Option<&P>,
        new: Option<P>,
        order: Ordering,
    ) -> Result<Option<P>, (Option<P>, *mut P)>; // Err returns `new` back, and the current pointer in AtomicPtr.

    // https://doc.rust-lang.org/std/sync/atomic/struct.AtomicPtr.html#method.compare_exchange
    pub fn compare_exchange(
        &self,
        current: Option<&P>,
        new: Option<P>,
        success: Ordering,
        failure: Ordering,
    ) -> Result<Option<P>, (Option<P>, *mut P)>; // Err returns `new` back, and the current pointer in AtomicPtr.

    // https://doc.rust-lang.org/std/sync/atomic/struct.AtomicPtr.html#method.compare_exchange_weak
    pub fn compare_exchange_weak(
        &self,
        current: Option<&P>,
        new: Option<P>,
        success: Ordering,
        failure: Ordering,
    ) -> Result<Option<P>, (Option<P>, *mut P)>; // Err returns `new` back, and the current pointer in AtomicPtr.
```

Closes #5