### PR TITLE
Use Acq/Rel ordering everywhere

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atom"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Colin Sherratt <colin.sherratt@gmail.com>"]
 license = "Apache-2.0"
 homepage = "https://github.com/slide-rs/atom"

--- a/examples/fifo.rs
+++ b/examples/fifo.rs
@@ -16,7 +16,7 @@ extern crate atom;
 
 use atom::*;
 use std::mem;
-use std::sync::{ Arc, Barrier};
+use std::sync::{Arc, Barrier};
 use std::thread;
 
 const THREADS: usize = 100;

--- a/examples/fifo.rs
+++ b/examples/fifo.rs
@@ -16,7 +16,7 @@ extern crate atom;
 
 use atom::*;
 use std::mem;
-use std::sync::{atomic::Ordering, Arc, Barrier};
+use std::sync::{ Arc, Barrier};
 use std::thread;
 
 const THREADS: usize = 100;
@@ -29,7 +29,7 @@ struct Link {
 impl Drop for Link {
     fn drop(&mut self) {
         // This is done to avoid a recusive drop of the List
-        while let Some(mut h) = self.next.atom().take(Ordering::Acquire) {
+        while let Some(mut h) = self.next.atom().take() {
             self.next = mem::replace(&mut h.next, AtomSetOnce::empty());
         }
     }
@@ -54,12 +54,12 @@ fn main() {
                 });
 
                 loop {
-                    while let Some(h) = hptr.next.get(Ordering::Acquire) {
+                    while let Some(h) = hptr.next.get() {
                         hptr = h;
                     }
 
                     my_awesome_node =
-                        match hptr.next.set_if_none(my_awesome_node, Ordering::Release) {
+                        match hptr.next.set_if_none(my_awesome_node) {
                             Some(v) => v,
                             None => break,
                         };
@@ -73,7 +73,7 @@ fn main() {
 
     let mut hptr = &*head;
     let mut count = 0;
-    while let Some(h) = hptr.next.get(Ordering::Acquire) {
+    while let Some(h) = hptr.next.get() {
         hptr = h;
         count += 1;
     }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,7 +1,7 @@
 extern crate atom;
 
 use atom::*;
-use std::sync::{atomic::Ordering, Arc};
+use std::sync::{Arc};
 use std::thread;
 
 fn main() {
@@ -9,7 +9,7 @@ fn main() {
     let shared_atom = Arc::new(Atom::empty());
 
     // set the value 75
-    shared_atom.swap(Box::new(75), Ordering::AcqRel);
+    shared_atom.swap(Box::new(75));
 
     // Spawn a bunch of thread that will try and take the value
     let threads: Vec<thread::JoinHandle<()>> = (0..8)
@@ -17,7 +17,7 @@ fn main() {
             let shared_atom = shared_atom.clone();
             thread::spawn(move || {
                 // Take the contents of the atom, only one will win the race
-                if let Some(v) = shared_atom.take(Ordering::Acquire) {
+                if let Some(v) = shared_atom.take() {
                     println!("I got it: {:?} :D", v);
                 } else {
                     println!("I did not get it :(");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,21 @@ use std::sync::Arc;
 
 /// An Atom wraps an AtomicPtr, it allows for safe mutation of an atomic
 /// into common Rust Types.
+///
+/// All `Ordering` is `AcqRel`.
+///
+/// ```
+/// // Create an empty atom
+/// use std::sync::Arc;
+/// use atom::Atom;
+///
+/// let shared_atom = Arc::new(Atom::empty());
+///
+/// shared_atom.set_if_none(Box::new(42));
+/// let old_value = shared_atom.swap(Box::new(75));
+///
+/// assert_eq!(old_value, Some(Box::new(42)));
+/// ```
 pub struct Atom<P>
 where
     P: IntoRawPtr + FromRawPtr,
@@ -155,9 +170,6 @@ where
     /// returned together with a raw pointer to the Atom's current unchanged
     /// value, which is **not safe to dereference**, especially if the Atom is
     /// accessed from multiple threads.
-    ///
-    /// `compare_and_swap` also takes an `Ordering` argument which describes
-    /// the memory ordering of this operation.
     pub fn compare_and_swap(
         &self,
         current: Option<&P>,
@@ -178,13 +190,6 @@ where
     /// The return value is a result indicating whether the new value was
     /// written and containing the previous value. On success this value is
     /// guaranteed to be equal to `current`.
-    ///
-    /// `compare_exchange` takes two `Ordering` arguments to describe the
-    /// memory ordering of this operation. The first describes the required
-    /// ordering if the operation succeeds while the second describes the
-    /// required ordering when the operation fails. The failure ordering can't
-    /// be `Release` or `AcqRel` and must be equivalent or weaker than the
-    /// success ordering.
     pub fn compare_exchange(
         &self,
         current: Option<&P>,
@@ -204,13 +209,6 @@ where
     /// even when the comparison succeeds, which can result in more efficient
     /// code on some platforms. The return value is a result indicating whether
     /// the new value was written and containing the previous value.
-    ///
-    /// `compare_exchange_weak` takes two `Ordering` arguments to describe the
-    /// memory ordering of this operation. The first describes the required
-    /// ordering if the operation succeeds while the second describes the
-    /// required ordering when the operation fails. The failure ordering can't
-    /// be `Release` or `AcqRel` and must be equivalent or weaker than the
-    /// success ordering.
     pub fn compare_exchange_weak(
         &self,
         current: Option<&P>,


### PR DESCRIPTION
Fixes #15

Changed all methods to use `Acquire`, `Release` or `AcqRel`, whichever is the strictest.

I had to remove the ordering parameters from all the methods, so it's a breaking change.